### PR TITLE
Change tests, examples, docs. QOL changes to get_tournament_matches().

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '4.0'}
-          - {os: macOS-latest, r: '4.0'}
+          - {os: windows-latest, r: '4.0.2'}
+          - {os: macOS-latest, r: '4.0.2'}
           - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '4.0', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04, r: '4.0.2', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,4 @@ Encoding: UTF-8
 LazyData: true
 URL: https://github.com/HaydenMacDonald/squashinformr
 BugReports: https://github.com/HaydenMacDonald/squashinformr/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/R/get_historical_rankings.R
+++ b/R/get_historical_rankings.R
@@ -14,8 +14,8 @@
 #'
 #' @examples
 #'
-#' ## Who were the top 10 players in both men's and women's singles in January 2019?
-#' \donttest{top10 <- get_historical_rankings(2019, "Jan", "both", 10)}
+#' ## Who were the top 5 players in both men's and women's singles in January 2019?
+#' \donttest{top5 <- get_historical_rankings(2019, "Jan", "both", 5)}
 #'
 #' @note This function takes substantial time to scrape the corresponding data because historical ranking tables are not available to non-premium members on SquashInfo. The historical rankings returned by this function are reverse-engineered from individual player ranking histories.
 #'

--- a/R/get_historical_rankings.R
+++ b/R/get_historical_rankings.R
@@ -15,7 +15,7 @@
 #' @examples
 #'
 #' ## Who were the top 5 players in both men's and women's singles in January 2019?
-#' \donttest{top5 <- get_historical_rankings(2019, "Jan", "both", 5)}
+#' \donttest{\dontrun{top5 <- get_historical_rankings(2019, "Jan", "both", 5)}}
 #'
 #' @note This function takes substantial time to scrape the corresponding data because historical ranking tables are not available to non-premium members on SquashInfo. The historical rankings returned by this function are reverse-engineered from individual player ranking histories.
 #'

--- a/R/get_matchup.R
+++ b/R/get_matchup.R
@@ -22,8 +22,8 @@
 #' ## Get tidy matchup data for Mohamed Elshorbagy vs Ali Farag
 #' \donttest{get_matchup(player_1 = "Mohamed Elshorbagy", player_2 = "Ali Farag", category = "mens", tidy = TRUE)}
 #'
-#' ## Get non-tidy matchup data for Nouran Gohar vs Camille Serme
-#' \donttest{get_matchup("Nouran Gohar", "Camille Serme", category = "womens", tidy = FALSE)}
+#' ## Get non-tidy matchup data for Nouran Gohar vs Nour El Sherbini
+#' \donttest{get_matchup("Nouran Gohar", "Nour El Sherbini", category = "womens", tidy = FALSE)}
 #'
 #' ## Get tidy match spread data for Paul Coll and Diego Elias
 #' \donttest{get_matchup("Paul Coll", "Diego Elias", category = "mens", tidy = TRUE, match_spread = TRUE)}
@@ -257,7 +257,7 @@ get_matchup <- function(player_1 = NULL, player_2 = NULL, ranks = NULL, category
         results <- cbind(results, profile_slugs) %>%
                                         as.data.frame()
 
-        ## Store data in mens_ranking_table
+        ## Store data in womens_ranking_table
         womens_ranking_table <- rbind(womens_ranking_table, results)
 
         # Find url in "Next" button

--- a/R/get_matchup.R
+++ b/R/get_matchup.R
@@ -22,8 +22,8 @@
 #' ## Get tidy matchup data for Mohamed Elshorbagy vs Ali Farag
 #' \donttest{get_matchup(player_1 = "Mohamed Elshorbagy", player_2 = "Ali Farag", category = "mens", tidy = TRUE)}
 #'
-#' ## Get non-tidy matchup data for Raneem El Welily vs Nouran Gohar
-#' \donttest{get_matchup("Raneem El Welily", "Nouran Gohar", category = "womens", tidy = FALSE)}
+#' ## Get non-tidy matchup data for Nouran Gohar vs Camille Serme
+#' \donttest{get_matchup("Nouran Gohar", "Camille Serme", category = "womens", tidy = FALSE)}
 #'
 #' ## Get tidy match spread data for Paul Coll and Diego Elias
 #' \donttest{get_matchup("Paul Coll", "Diego Elias", category = "mens", tidy = TRUE, match_spread = TRUE)}

--- a/R/get_tournament_matches.R
+++ b/R/get_tournament_matches.R
@@ -335,7 +335,7 @@ get_tournament_matches <- function(tournament = NULL, year = 2020, world_tour = 
       ## Clean results
       result <- result %>%
                   ## Remove 'round' rows
-                  filter(X1 != "Final:", X1 != "Semi-finals:", X1 != "Quarter-finals:", X1 != "3rd round:", X1 != "2nd round:", X1 != "1st round:") %>%
+                  filter(X1 != "Final:", X1 != "Third place play-off:", X1 != "Semi-finals:", X1 != "Quarter-finals:", X1 != "3rd round:", X1 != "2nd round:", X1 != "1st round:") %>%
                   mutate(X1 = str_replace_all(X1, pattern = regex("[:punct:]"), replacement = ""),  ## Remove punctuation from match column
 
                          ## Extract player names from match column
@@ -412,11 +412,15 @@ get_tournament_matches <- function(tournament = NULL, year = 2020, world_tour = 
                          games_won = NA_real_,
                          games_lost = NA_real_)
 
+    ## Filter out extraneous rows with NA in player_1 and player_2
+    matches <- matches %>%
+                  filter(is.na(player_1) == FALSE & is.na(player_2) == FALSE)
+
     ## For each row in matches
     for (j in seq_along(matches$games)) {
 
       ## if there are no games, go to next row, else extract match
-      if (length(matches$games[[j]]) == 0) { next } else { match <- matches$games[[j]] }
+      if (length(matches$games[[j]]) == 0 | matches$match_winner[[j]] == "TBD") { next } else { match <- matches$games[[j]] }
 
       ## start with 0 game wins and game losses
       wins <- 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,9 @@ environment:
   NOT_CRAN: true
   # env vars that may need to be set, at least temporarily, from time to time
   # see https://github.com/krlmlr/r-appveyor#readme for details
-  # USE_RTOOLS: true
+  USE_RTOOLS: true
   R_REMOTES_STANDALONE: true
-  R_VERSION: 4.0.0
+  R_VERSION: 4.0.2
   R_ARCH: x64
   RTOOLS_VERSION: 40
   _R_CHECK_DONTTEST_EXAMPLES_: false

--- a/man/get_historical_rankings.Rd
+++ b/man/get_historical_rankings.Rd
@@ -26,8 +26,8 @@ This function takes substantial time to scrape the corresponding data because hi
 }
 \examples{
 
-## Who were the top 10 players in both men's and women's singles in January 2019?
-\donttest{top10 <- get_historical_rankings(2019, "Jan", "both", 10)}
+## Who were the top 5 players in both men's and women's singles in January 2019?
+\donttest{top5 <- get_historical_rankings(2019, "Jan", "both", 5)}
 
 }
 \references{

--- a/man/get_historical_rankings.Rd
+++ b/man/get_historical_rankings.Rd
@@ -27,7 +27,7 @@ This function takes substantial time to scrape the corresponding data because hi
 \examples{
 
 ## Who were the top 5 players in both men's and women's singles in January 2019?
-\donttest{top5 <- get_historical_rankings(2019, "Jan", "both", 5)}
+\donttest{\dontrun{top5 <- get_historical_rankings(2019, "Jan", "both", 5)}}
 
 }
 \references{

--- a/man/get_matchup.Rd
+++ b/man/get_matchup.Rd
@@ -40,8 +40,8 @@ This function only returns data from players ranked in the most recent PSA ranki
 ## Get tidy matchup data for Mohamed Elshorbagy vs Ali Farag
 \donttest{get_matchup(player_1 = "Mohamed Elshorbagy", player_2 = "Ali Farag", category = "mens", tidy = TRUE)}
 
-## Get non-tidy matchup data for Raneem El Welily vs Nouran Gohar
-\donttest{get_matchup("Raneem El Welily", "Nouran Gohar", category = "womens", tidy = FALSE)}
+## Get non-tidy matchup data for Nouran Gohar vs Nour El Sherbini
+\donttest{get_matchup("Nouran Gohar", "Nour El Sherbini", category = "womens", tidy = FALSE)}
 
 ## Get tidy match spread data for Paul Coll and Diego Elias
 \donttest{get_matchup("Paul Coll", "Diego Elias", category = "mens", tidy = TRUE, match_spread = TRUE)}

--- a/tests/testthat/test_get_matchup.R
+++ b/tests/testthat/test_get_matchup.R
@@ -10,8 +10,8 @@ test_that("test get_matchup for wrong input errors", {
   expect_error(get_matchup(player_1 = NULL, player_2 = NULL, category = "mens", tidy = TRUE))
   expect_error(get_matchup(player_1 = NULL, player_2 = NULL, ranks = 1, category = "mens", tidy = TRUE))
   expect_error(get_matchup("Mohamed Elshorbagy", "Ali Farag", ranks = 1:2, category = "mens", tidy = TRUE))
-  expect_error(get_matchup("Raneem El Welily", "Nouran Gohar", ranks = 1:2, category = "womens", tidy = TRUE))
-  expect_error(get_matchup("Mohamed Elshorbagy", "Raneem El Welily", category = "both", tidy = TRUE))
+  expect_error(get_matchup("Nouran Gohar", "Nour El Sherbini", ranks = 1:2, category = "womens", tidy = TRUE))
+  expect_error(get_matchup("Mohamed Elshorbagy", "Nouran Gohar", category = "both", tidy = TRUE))
   expect_error(get_matchup("Mohamed Elshorbagy", ranks = 1:2, category = "mens", tidy = TRUE))
   expect_error(get_matchup("Mohamed Elshorbagy", "Ali Farag", ranks = 1, category = "mens", tidy = TRUE))
   expect_error(get_matchup("Mohamed Elshorbagy", "Ali Farag", "Karim Abdel Gawad", category = "mens", tidy = TRUE))
@@ -35,7 +35,7 @@ test_that("test get_matchup for proper outputs", {
   expect_equal(nrow(df), 23)
 
   ## category == "womens"
-  df <- get_matchup("Raneem El Welily", "Nouran Gohar", category = "womens", tidy = TRUE)
+  df <- get_matchup("Nouran Gohar", "Nour El Sherbini", category = "womens", tidy = TRUE)
   expect_is(df, "data.frame")
   expect_is(df, "tbl")
   expect_equal(nrow(df), 1)

--- a/tests/testthat/test_get_player_rankings_history.R
+++ b/tests/testthat/test_get_player_rankings_history.R
@@ -45,7 +45,7 @@ test_that("test get_player_rankings_history for proper outputs", {
   expect_is(df, "tbl")
 
   ## category == "womens"
-  df <- get_player_rankings_history("Raneem El Welily", category = "womens")
+  df <- get_player_rankings_history("Nouran Gohar", category = "womens")
   expect_is(df, "data.frame")
   expect_is(df, "tbl")
 

--- a/tests/testthat/test_get_player_recent_games.R
+++ b/tests/testthat/test_get_player_recent_games.R
@@ -53,7 +53,7 @@ test_that("test get_player_recent_games for proper outputs", {
   expect_is(df, "tbl")
 
   ## category == "womens"
-  df <- get_player_recent_games("Raneem El Welily", category = "womens")
+  df <- get_player_recent_games("Nouran Gohar", category = "womens")
   expect_is(df, "data.frame")
   expect_is(df, "tbl")
 

--- a/tests/testthat/test_get_player_recent_matches.R
+++ b/tests/testthat/test_get_player_recent_matches.R
@@ -54,7 +54,7 @@ test_that("test get_player_recent_matches for proper outputs", {
   expect_is(df, "tbl")
 
   ## category == "womens"
-  df <- get_player_recent_matches("Raneem El Welily", category = "womens")
+  df <- get_player_recent_matches("Nouran Gohar", category = "womens")
   expect_is(df, "data.frame")
   expect_is(df, "tbl")
 

--- a/tests/testthat/test_get_player_recent_results.R
+++ b/tests/testthat/test_get_player_recent_results.R
@@ -53,7 +53,7 @@ test_that("test get_player_recent_results for proper outputs", {
   expect_is(df, "tbl")
 
   ## category == "womens"
-  df <- get_player_recent_results("Raneem El Welily", category = "womens")
+  df <- get_player_recent_results("Nouran Gohar", category = "womens")
   expect_is(df, "data.frame")
   expect_is(df, "tbl")
 


### PR DESCRIPTION
I have made several changes to the examples, unit tests, and documentation of several functions. Most of these were in response to SquashInfo's removal of Raneem El Welily from the Women's rankings table. Examples or tests using her name were replaced by other players.

Additionally, I made a several quality of life changes to `get_tournament_matches()`:

- Added logic to remove extraneous rows representing matches with no players
- Added logic to include matches that have yet to be played (match_winner == "TBD")

Hopefully these changes help the master branch pass RCMDCHECK on GH Actions and Travis.