### PR TITLE
fix: changed html_nodes and html_table parsing in get_tournament_objects()

### DIFF
--- a/R/get_tournament_.R
+++ b/R/get_tournament_.R
@@ -679,6 +679,7 @@ get_tournament_objects <- function(tournaments = NULL, level = NULL) {
 
     ## Find html tables
     result <- current_page %>%
+      html_nodes(xpath = '//*[@id="results"]') %>%
       html_nodes("table") %>%
       html_table() %>%
       as.data.frame()


### PR DESCRIPTION
Addresses issue with parsing tournament data from pages that now includes two table tags instead of one.